### PR TITLE
Update request url parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MusicThread RSS
 
-A light microservice to serve [Atom 1.0 Feeds](https://www.rfc-editor.org/rfc/rfc4287) for [MusicThread](https://musicthread.app) threads using the same URL path schema (i.e. `/thread/<THREAD_KEY>`).
+A light microservice to serve [Atom 1.0 Feeds](https://www.rfc-editor.org/rfc/rfc4287) for [MusicThread](https://musicthread.app) threads using the same URL path schema (i.e. `/thread/<THREAD_KEY>`). Private threads are not currently supported.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "musicthread-rss",
   "version": "0.9.0",
+  "private": true,
+  "main": "src/main.js",
   "devDependencies": {
     "wrangler": "2.0.8"
   },
-  "private": true,
   "scripts": {
     "start": "wrangler dev",
     "deploy": "wrangler publish"

--- a/src/main.js
+++ b/src/main.js
@@ -142,8 +142,6 @@ function parseThreadKey(url) {
     const requestURL = new URL(url);
     const pathComponents = requestURL.pathname.substring(1).split("/");
 
-    console.log(pathComponents)
-
     if (pathComponents.length !== 2) {
         return null;
     }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,5 @@
 name = "musicthread-rss"
 main = "src/main.js"
 compatibility_date = "2022-06-08"
+type = "javascript"
+workers_dev = true


### PR DESCRIPTION
This PR updates the way the script parses the request URL.

The important parts are:
- We only work with the request path
- Unsupported urls return 404 status code
- We explicitly check for the `thread` path component
- We don't assume a specific length for the thread key

Additionally I also made some minor edits to the wrangler setup (it didn't immediately run for me), and added a notice about private threads (which I think we should address separately and in the future).