### PR TITLE
Use he library for entity encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "musicthread-feed-generator",
-  "version": "0.0.1",
+  "name": "musicthread-rss",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "musicthread-feed-generator",
-      "version": "0.0.1",
+      "name": "musicthread-rss",
+      "version": "0.9.0",
+      "dependencies": {
+        "he": "^1.2.0"
+      },
       "devDependencies": {
         "wrangler": "2.0.8"
       }
@@ -692,6 +695,14 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/html-rewriter-wasm": {
@@ -1424,6 +1435,11 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "html-rewriter-wasm": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "cf-login": "wrangler login",
     "dev": "wrangler dev",
     "deploy": "wrangler publish"
+  },
+  "dependencies": {
+    "he": "^1.2.0"
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,4 @@
 name = "musicthread-rss"
 main = "src/main.js"
 compatibility_date = "2022-06-08"
-type = "javascript"
 workers_dev = true


### PR DESCRIPTION
This PR uses `he.js` for encoding html entities in the RSS feed.

It also breaks down parts of generating the feed into separate functions for (hopefully) easier readability.

The feed generation is moved within the `try/catch` as `he` can throw errors in some situations.