### PR TITLE
Rename RSS -> Atom/feed/webfeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# MusicThread RSS
+# MusicThread Web Feeds
 
 A light microservice to serve [Atom 1.0 Feeds](https://www.rfc-editor.org/rfc/rfc4287) for [MusicThread](https://musicthread.app/).
 
-People use the RSS feeds for following updates to specific threads via their RSS reader, or as part of automations with services like [IFTTT](https://ifttt.com). If you have a novel use for MusicThread RSS, please let us know!
+People use web feeds for following updates to specific threads via a feed reader/aggregator, or as part of automations with services like [IFTTT](https://ifttt.com). If you have a novel use for MusicThread Web Feeds, please let us know!
 
-MusicThread RSS is run by MusicThread at https://rss.musicthread.app/ but individuals may want to run their own fork with modifications.
+MusicThread Web Feeds are available at https://feed.musicthread.app/ but individuals may want to run their own fork with modifications.
 
 URLs follow the same path structure as on the main website (i.e. `/thread/<THREAD_KEY>`). Private threads are not currently supported and attempting to access them will return an error.
 
 ## Architecture
 
-MusicThread RSS is designed to be run using [Cloudflare Workers](https://workers.cloudflare.com/).
+`musicthread-webfeed` is designed to be run using [Cloudflare Workers](https://workers.cloudflare.com/).
 
 The code is available in a single Javascript file (`src/main.js`) and should be trivially integrated into other environments if needed.
 
-If you're interested in opening a PR to support running MusicThread RSS in other environments, please open an issue so we can discuss it first.
+If you're interested in opening a PR to add or change features, please open an issue so we can discuss your plans first.
 
 ### Local development
 
-MusicThread RSS requires [node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [wrangler](https://github.com/cloudflare/wrangler2) and a [Cloudflare](https://www.cloudflare.com) account.
+`musicthread-webfeed` requires [node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [wrangler](https://github.com/cloudflare/wrangler2) and a [Cloudflare](https://www.cloudflare.com) account.
 
 An introduction to Cloudflare Workers is available here: ["Get started guide"](https://developers.cloudflare.com/workers/get-started/guide).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "musicthread-rss",
+  "name": "musicthread-webfeed",
   "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "musicthread-rss",
+      "name": "musicthread-webfeed",
       "version": "0.9.0",
       "dependencies": {
         "he": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "musicthread-rss",
+  "name": "musicthread-webfeed",
   "version": "0.9.0",
   "private": true,
   "main": "src/main.js",

--- a/src/main.js
+++ b/src/main.js
@@ -26,8 +26,8 @@ async function main(request) {
             return new Response(errorMessage, { status: response.status });
         }
 
-        // Generate RSS Feed
-        const feed = generateRSSFeed(json);
+        // Generate Atom Feed
+        const feed = generateAtomFeed(json);
 
         // Return successful HTTP response
         return new Response(feed, {
@@ -58,7 +58,7 @@ async function fetchThread(key) {
  * @param  {Object} link The Link object obtained from the MusicThread API
  * @return {String} The summary element or empty string
  */
-function generateRSSFeedEntrySummary(link) {
+function generateAtomFeedEntrySummary(link) {
     if (link.description == "") {
         return "";
     }
@@ -71,10 +71,10 @@ function generateRSSFeedEntrySummary(link) {
  * @param  {Object} link The Link object obtained from the MusicThread API
  * @return {Array<String>} The valid XML element representing the given link
  */
-function generateRssFeedEntry(link) {
+function generateAtomFeedEntry(link) {
     const linkURL = `https://musicthread.app/link/${link.key}`
 
-    const summaryContent = generateRSSFeedEntrySummary(link)
+    const summaryContent = generateAtomFeedEntrySummary(link)
 
     return `
 <entry>
@@ -104,7 +104,7 @@ function generateRssFeedEntry(link) {
  * @param  {Object} thread The Thread object obtained from the MusicThread API
  * @return {String} The subtitle element or empty string
  */
-function generateRSSFeedThreadSummary(thread) {
+function generateAtomFeedThreadSummary(thread) {
     if (thread.description == "") {
         return ""
     }
@@ -117,29 +117,29 @@ function generateRSSFeedThreadSummary(thread) {
  * @param  {Object} thread The Thread object obtained from the MusicThread API
  * @return {Array<String>} The array of valid XML tags representing the thread tags
  */
-function generateRSSFeedCategories(thread) {
+function generateAtomFeedCategories(thread) {
     return thread.tags.map(tag => {
         return `<category term="${encodeHtml(tag)}" />`
     })
 }
 
 /**
- * Returns a valid RSS feed for the provided MusicThread as a String XML.
+ * Returns a valid Atom feed for the provided MusicThread as a String XML.
  *
  * @param  {Object} root The JSON response returned by MusicThread's "Get Thread" API
- * @return {String} The XML RSS Feed for this thread
+ * @return {String} The XML Atom Feed for this thread
  */
-function generateRSSFeed(root) {
-    const feedURL = `https://rss.musicthread.app/thread/${root.thread.key}`;
+function generateAtomFeed(root) {
+    const feedURL = `https://feed.musicthread.app/thread/${root.thread.key}`;
     const threadURL = `https://musicthread.app/thread/${root.thread.key}`;
 
-    const subtitleContent = generateRSSFeedThreadSummary(root.thread);
-    const categoryContentItems = generateRSSFeedCategories(root.thread).join("\n");
-    const entryContentItems = root.links.map(link => generateRssFeedEntry(link)).join("\n");
+    const subtitleContent = generateAtomFeedThreadSummary(root.thread);
+    const categoryContentItems = generateAtomFeedCategories(root.thread).join("\n");
+    const entryContentItems = root.links.map(link => generateAtomFeedEntry(link)).join("\n");
 
     return `<?xml version="1.0" encoding="utf-8" ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <generator uri="https://github.com/brushedtype/musicthread-rss" version="0.9.0">MusicThread RSS</generator>
+    <generator uri="https://github.com/brushedtype/musicthread-webfeed" version="0.9.0">MusicThread Web Feeds</generator>
     <updated>${(new Date()).toISOString()}</updated>
 
     <id>${feedURL}</id>
@@ -172,7 +172,7 @@ String.prototype.capitalize = function() {
 
 /**
  * Generates the content body for a given thread "link". This is what's
- * displayed in RSS readers when you select a particular entry.
+ * displayed in Atom readers when you select a particular entry.
  *
  * @param  {Object} link The MusicThread link object
  * @return {String} An HTML String for the provided MusicThread link

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "musicthread-rss"
+name = "musicthread-webfeed"
 main = "src/main.js"
 compatibility_date = "2022-06-08"
 workers_dev = true


### PR DESCRIPTION
So... what we've actually implemented is Atom feeds... My mistake with the original naming of the repo.

This PR renames the project to MusicThread Web Feeds and updates the code and documentation to reflect this.

The project on Cloudflare workers has now been set up too and is available at `feed.musicthread.app` (e.g. https://feed.musicthread.app/thread/221MoMPiOUJiqUoTVONYHiqjZEK)

Once reviewed and merged, I'll update this repo name to `musicthread-webfeed` too.